### PR TITLE
Fix: Correct typo in logo text

### DIFF
--- a/src/components/shared/logo.tsx
+++ b/src/components/shared/logo.tsx
@@ -6,7 +6,7 @@ export default function Logo() {
       href={"/"}
       className="text-5xl font-bold text-black transition ease-out hover:text-black-700"
     >
-      SaeeNotes
+      Saee'sNotes
       <span className="text-purple-400">.</span>
     </Link>
   );


### PR DESCRIPTION
### Purpose

The goal of this change is to correct a typo in the application's logo text.

### Code changes

- In `src/components/shared/logo.tsx`, the text "SaeeNotes" has been updated to "Saee'sNotes".

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b95d21df79e04345964b51d061363f75/zen-garden)

👀 [Preview Link](https://b95d21df79e04345964b51d061363f75-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b95d21df79e04345964b51d061363f75</projectId>-->
<!--<branchName>zen-garden</branchName>-->